### PR TITLE
fix stdenv.lib warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
               cabal-install
               nvchecker
               nix-prefetch-git
+              cabal2nix #cd nix && cabal2nix ../. > default.nix && ..
             ]).envFunc { };
           packages.nvfetcher-lib = with haskell.lib;
             overrideCabal (haskellPackages.nvfetcher) (drv: {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,6 +1,7 @@
-{ mkDerivation, aeson, base, binary, bytestring, containers, extra, free
-, microlens, microlens-th, neat-interpolation, shake, stdenv, text, tomland
-, transformers, validation-selective }:
+{ mkDerivation, aeson, base, binary, bytestring, containers, extra
+, free, lib, microlens, microlens-th, neat-interpolation, shake
+, text, tomland, transformers, validation-selective
+}:
 mkDerivation {
   pname = "nvfetcher";
   version = "0.1.0.0";
@@ -8,38 +9,15 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    aeson
-    base
-    binary
-    bytestring
-    containers
-    extra
-    free
-    microlens
-    microlens-th
-    neat-interpolation
-    shake
-    text
-    transformers
+    aeson base binary bytestring containers extra free microlens
+    microlens-th neat-interpolation shake text transformers
   ];
   executableHaskellDepends = [
-    aeson
-    base
-    binary
-    bytestring
-    containers
-    extra
-    free
-    microlens
-    microlens-th
-    neat-interpolation
-    shake
-    text
-    tomland
-    transformers
+    aeson base binary bytestring containers extra free microlens
+    microlens-th neat-interpolation shake text tomland transformers
     validation-selective
   ];
   homepage = "https://github.com/berberman/nvfetcher";
   description = "Generate nix sources expr for the latest version of packages";
-  license = stdenv.lib.licenses.mit;
+  license = lib.licenses.mit;
 }


### PR DESCRIPTION
Using `nix develop` to generates the cabal2nix.nix

```
trace: Warning: `stdenv.lib` is deprecated and will be removed in the next release. Please use `lib` instead. For more information see https://github.com/NixOS/nixpkgs/issues/108938
```