### PR TITLE
Support vscode extensions

### DIFF
--- a/Main_example.hs
+++ b/Main_example.hs
@@ -39,3 +39,5 @@ packageSet = do
       `sourceManual` "8a5f37a8f80a3b05290707febf57e88661cee442"
       `fetchGit` "https://gist.github.com/NickCao/6c4dbc4e15db5da107de6cdb89578375"
       `hasCargoLock` "Cargo.lock"
+
+  define $ package "vscode-LiveServer" `fromOpenVsx` ("ritwickdey", "LiveServer")

--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ Version source -- how do we track upstream version updates?
 * `src.repology = project:repo` -- the latest version from repology
 * `src.webpage = web_url` and `src.regex` -- a string in webpage that matches with regex
 * `src.httpheader = request_url` and `src.regex` -- a string in http header that matches with regex
+* `src.openvsx = publisher.ext_name` -- the latest version of a vscode extension from open vsx
+* `src.vsmarketplace = publisher.ext_name` -- the latest version of a vscode extension from vscode marketplace
 
 
 Optional list options for some version sources (`src.github_tag`, `src.webpage`, and `src.httpheader`),
@@ -163,6 +165,8 @@ How do we fetch the package source if we have the target version number?
 * `fetch.pypi = pypi_name`
 * `fetch.git = git_url`
 * `fetch.url = url`
+* `fetch.openvsx = publisher.ext_name`
+* `fetch.vsmarketplace = publisher.ext_name`
 
 
 Optional `nix-prefetch-git` config, which make sense only when the fetcher equals to `fetch.github` or `fetch.git`.

--- a/app/Config/VersionSource.hs
+++ b/app/Config/VersionSource.hs
@@ -26,7 +26,9 @@ versionSourceCodec =
       manualCodec,
       repologyCodec,
       webpageCodec,
-      httpHeaderCodec
+      httpHeaderCodec,
+      openVsxCodec,
+      vscodeMarketplaceCodec
     ]
 
 --------------------------------------------------------------------------------
@@ -175,3 +177,41 @@ httpHeaderCodec :: TomlCodec VersionSource
 httpHeaderCodec = dimatch matchHttpHeader (uncurry3 HttpHeader) httpHeaderICodec
 
 --------------------------------------------------------------------------------
+
+matchOpenVsx :: VersionSource -> Maybe (Text, Text)
+matchOpenVsx x = (,) <$> x ^? ovPublisher <*> x ^? ovExtName
+
+openVsxICodec :: TomlCodec (Text, Text)
+openVsxICodec =
+  textBy
+    (\(publisher, extName) -> publisher <> "." <> extName)
+    ( \t ->
+        case T.split (== '.') t of
+          -- assume we can't have '.' in extension's name
+          [publisher, extName] -> Right (publisher, extName)
+          _ -> Left "unexpected openvsx source format: it should be something like [publisher].[extName]"
+    )
+    "src.openvsx"
+
+openVsxCodec :: TomlCodec VersionSource
+openVsxCodec = dimatch matchOpenVsx (uncurry OpenVsx) openVsxICodec
+
+--------------------------------------------------------------------------------
+
+matchVscodeMarketplace :: VersionSource -> Maybe (Text, Text)
+matchVscodeMarketplace x = (,) <$> x ^? vsmPublisher <*> x ^? vsmExtName
+
+vscodeMarketplaceICodec :: TomlCodec (Text, Text)
+vscodeMarketplaceICodec =
+  textBy
+    (\(publisher, extName) -> publisher <> "." <> extName)
+    ( \t ->
+        case T.split (== '.') t of
+          -- assume we can't have '.' in extension's name
+          [publisher, extName] -> Right (publisher, extName)
+          _ -> Left "unexpected vscode marketplace source format: it should be something like [publisher].[extName]"
+    )
+    "src.vsmarketplace"
+
+vscodeMarketplaceCodec :: TomlCodec VersionSource
+vscodeMarketplaceCodec = dimatch matchVscodeMarketplace (uncurry VscodeMarketplace) vscodeMarketplaceICodec

--- a/flake.nix
+++ b/flake.nix
@@ -39,6 +39,18 @@
         hydraJobs = { inherit packages; };
       }) // {
         overlay = final: prev: {
+
+          # remove it once 2.4 is released
+          nvchecker = prev.nvchecker.overrideAttrs (old: {
+            patches = [];
+            src = final.fetchFromGitHub {
+              owner = "lilydjwg";
+              repo = "nvchecker";
+              rev = "151b03801fcea7c96af210fd45de77b59ee0d82c";
+              sha256 = "Jvnu1J+fM7JG+oyj2thS07kdnQ5Qq1vDdt2zN2tcgus=";
+            };
+          });
+
           haskellPackages = prev.haskellPackages.override (old: {
             overrides = final.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
               nvfetcher = with final.haskell.lib;

--- a/nvfetcher_example.toml
+++ b/nvfetcher_example.toml
@@ -44,3 +44,7 @@ src.manual = "8a5f37a8f80a3b05290707febf57e88661cee442"
 fetch.git = "https://gist.github.com/NickCao/6c4dbc4e15db5da107de6cdb89578375"
 # Calculate outputHashes for git dependencies in cargo lock
 cargo_lock = "Cargo.lock"
+
+[vscode-LiveServer]
+src.openvsx = "ritwickdey.LiveServer"
+fetch.openvsx = "ritwickdey.LiveServer"

--- a/src/NvFetcher/NixFetcher.hs
+++ b/src/NvFetcher/NixFetcher.hs
@@ -39,6 +39,8 @@ module NvFetcher.NixFetcher
     gitHubReleaseFetcher,
     gitFetcher,
     urlFetcher,
+    openVsxFetcher,
+    vscodeMarketplaceFetcher,
   )
 where
 
@@ -128,3 +130,21 @@ gitHubReleaseFetcher (owner, repo) fp (coerce -> ver) =
 -- | Create a fetcher from url
 urlFetcher :: Text -> NixFetcher Fresh
 urlFetcher = flip FetchUrl ()
+
+-- | Create a fetcher from openvsx
+openVsxFetcher ::
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageFetcher
+openVsxFetcher (publisher, extName) (coerce -> ver) =
+  urlFetcher
+    [trimming|https://open-vsx.org/api/$publisher/$extName/$ver/file/$publisher.$extName-$ver.vsix|]
+
+-- | Create a fetcher from vscode marketplace
+vscodeMarketplaceFetcher ::
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageFetcher
+vscodeMarketplaceFetcher (publisher, extName) (coerce -> ver) =
+  urlFetcher
+    [trimming|https://$publisher.gallery.vsassets.io/_apis/public/gallery/publisher/$publisher/extension/$extName/$ver/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage|]

--- a/src/NvFetcher/Nvchecker.hs
+++ b/src/NvFetcher/Nvchecker.hs
@@ -127,6 +127,12 @@ genNvConfig pkg options versionSource = table (fromString $ T.unpack $ coerce pk
         "url" =: Text _vurl
         "regex" =: Text _regex
         genListOptions _listOptions
+      OpenVsx {..} -> do
+        "source" =: "openvsx"
+        "openvsx" =: Text (_ovPublisher <> "." <> _ovExtName)
+      VscodeMarketplace {..} -> do
+        "source" =: "vsmarketplace"
+        "vsmarketplace" =: Text (_vsmPublisher <> "." <> _vsmExtName)
     genListOptions ListOptions {..} = do
       "include_regex" =:? _includeRegex
       "exclude_regex" =:? _excludeRegex

--- a/src/NvFetcher/PackageSet.hs
+++ b/src/NvFetcher/PackageSet.hs
@@ -47,6 +47,8 @@ module NvFetcher.PackageSet
     fromGitHubTag,
     fromGitHubTag',
     fromPypi,
+    fromOpenVsx,
+    fromVscodeMarketplace,
 
     -- ** Version sources
     sourceGitHub,
@@ -60,6 +62,8 @@ module NvFetcher.PackageSet
     sourceRepology,
     sourceWebpage,
     sourceHttpHeader,
+    sourceOpenVsx,
+    sourceVscodeMarketplace,
 
     -- ** Fetchers
     fetchGitHub,
@@ -69,6 +73,8 @@ module NvFetcher.PackageSet
     fetchGit,
     fetchGit',
     fetchUrl,
+    fetchOpenVsx,
+    fetchVscodeMarketplace,
 
     -- * Addons
     extractSource,
@@ -306,6 +312,22 @@ fromPypi ::
     (Prod (PackageFetcher : VersionSource : r))
 fromPypi e p = fetchPypi (sourcePypi e p) p
 
+-- | A synonym of 'fetchOpenVsx' and 'sourceOpenVsx'
+fromOpenVsx ::
+  PackageSet (Prod r) ->
+  (Text, Text) ->
+  PackageSet
+    (Prod (PackageFetcher : VersionSource : r))
+fromOpenVsx e x = fetchOpenVsx (sourceOpenVsx e x) x
+
+-- | A synonym of 'fetchVscodeMarketplace' and 'sourceVscodeMarketplace'
+fromVscodeMarketplace ::
+  PackageSet (Prod r) ->
+  (Text, Text) ->
+  PackageSet
+    (Prod (PackageFetcher : VersionSource : r))
+fromVscodeMarketplace e x = fetchVscodeMarketplace (sourceVscodeMarketplace e x) x
+
 --------------------------------------------------------------------------------
 
 -- | This package follows the latest github release
@@ -395,6 +417,22 @@ sourceHttpHeader ::
   PackageSet (Prod (VersionSource : r))
 sourceHttpHeader e (_vurl, _regex, f) = src e $ HttpHeader _vurl _regex $ f def
 
+-- | This package follows a version in Open VSX
+sourceOpenVsx ::
+  PackageSet (Prod r) ->
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageSet (Prod (VersionSource : r))
+sourceOpenVsx e (_ovPublisher, _ovExtName) = src e OpenVsx {..}
+
+-- | This package follows a version in Vscode Marketplace
+sourceVscodeMarketplace ::
+  PackageSet (Prod r) ->
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageSet (Prod (VersionSource : r))
+sourceVscodeMarketplace e (_vsmPublisher, _vsmExtName) = src e VscodeMarketplace {..}
+
 --------------------------------------------------------------------------------
 
 -- | This package is fetched from a github repo
@@ -465,6 +503,22 @@ fetchUrl ::
   (Version -> Text) ->
   PackageSet (Prod (PackageFetcher : r))
 fetchUrl e f = fetch e (urlFetcher . f)
+
+-- | This package is fetched from Open VSX
+fetchOpenVsx ::
+  PackageSet (Prod r) ->
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageSet (Prod (PackageFetcher : r))
+fetchOpenVsx e = fetch e . vscodeMarketplaceFetcher
+
+-- | This package is fetched from Vscode Marketplace
+fetchVscodeMarketplace ::
+  PackageSet (Prod r) ->
+  -- | publisher and extension name
+  (Text, Text) ->
+  PackageSet (Prod (PackageFetcher : r))
+fetchVscodeMarketplace e = fetch e . vscodeMarketplaceFetcher
 
 --------------------------------------------------------------------------------
 

--- a/src/NvFetcher/Types.hs
+++ b/src/NvFetcher/Types.hs
@@ -159,6 +159,8 @@ data VersionSource
   | Repology {_repology :: Text, _repo :: Text}
   | Webpage {_vurl :: Text, _regex :: Text, _listOptions :: ListOptions}
   | HttpHeader {_vurl :: Text, _regex :: Text, _listOptions :: ListOptions}
+  | OpenVsx {_ovPublisher :: Text, _ovExtName :: Text}
+  | VscodeMarketplace {_vsmPublisher :: Text, _vsmExtName :: Text}
   deriving (Show, Typeable, Eq, Ord, Generic, Hashable, Binary, NFData)
 
 -- | The input of nvchecker


### PR DESCRIPTION
Closes #14 

TODO:
* [ ] Pull `publisher` and `name` into nix expr

Now
```toml
[testa]
src.openvsx = "ritwickdey.LiveServer"
fetch.openvsx = "ritwickdey.LiveServer"

[testb]
src.vsmarketplace = "ritwickdey.LiveServer"
fetch.vsmarketplace = "ritwickdey.LiveServer"
```
can produce
```nix
{
  testa = {
    pname = "testa";
    version = "5.6.1";
    src = fetchurl {
      sha256 = "1hzk5g7m3mvgi5jyv3xfw6q8rz21vwa1r1a8f8iik9pgma3pkymq";
      url = "https://open-vsx.org/api/ritwickdey/LiveServer/5.6.1/file/ritwickdey.LiveServer-5.6.1.vsix";
    };
  };
  testb = {
    pname = "testb";
    version = "5.6.1";
    src = fetchurl {
      sha256 = "077arf3hsn1yb8xdhlrax5gf93ljww78irv4gm8ffmsqvcr1kws0";
      url = "https://ritwickdey.gallery.vsassets.io/_apis/public/gallery/publisher/ritwickdey/extension/LiveServer/5.6.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
    };
  };
}
```