### PR TITLE
Support pass through additional attrs from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,11 @@ so we can use this instead TOFU `cargoSha256` for Rust packageing. `nvfetcher` s
 extracting the lock file to build and calculating `cargoLock.outputHashes`, as long as you set the config
 * `cargo_lock = cargo_lock_path` - relative to the source root
 
+#### Passthru
+
+*passthru* config, an additional set of attrs to be generated.
+
+  * `passthru = { k1 = "v1", k2 = "v2", ... }`
 
 ### Haskell library
 
@@ -201,16 +206,6 @@ You can find an example of using nvfetcher in the library way, see [`Main_exampl
 
 For details of the library, documentation of released versions is available on [Hackage](https://hackage.haskell.org/package/nvfetcher),
 and of master is on our [github pages](https://nvfetcher.berberman.space).
-
-## Limitations
-
-There is no way to check the equality over version sources and fetchers, so If you change either of them in a package,
-you will need to rebuild everything, i.e. run `nvfetcher clean` to remove shake databsae, to make sure that
-our build system works correctly. We could automate this process, for example,
-calculate the hash of the configuration file and bump `shakeVersion` to trigger the rebuild.
-However, this shouldn't happen frequently and we want to minimize the changes, so it's left for you to do manually.
-
-> Adding or removing a package doesn't require such rebuild
 
 ## Contributing
 

--- a/nvfetcher_example.toml
+++ b/nvfetcher_example.toml
@@ -48,3 +48,4 @@ cargo_lock = "Cargo.lock"
 [vscode-LiveServer]
 src.openvsx = "ritwickdey.LiveServer"
 fetch.openvsx = "ritwickdey.LiveServer"
+passthru = { publisher = "ritwickdey", name = "LiveServer" }

--- a/src/NvFetcher/Types.hs
+++ b/src/NvFetcher/Types.hs
@@ -56,6 +56,7 @@ module NvFetcher.Types
     PackageFetcher,
     PackageExtractSrc (..),
     PackageCargoFilePath (..),
+    PackagePassthru (..),
     Package (..),
     PackageKey (..),
   )
@@ -250,13 +251,17 @@ newtype PackageExtractSrc = PackageExtractSrc (NE.NonEmpty FilePath)
 
 newtype PackageCargoFilePath = PackageCargoFilePath FilePath
 
+newtype PackagePassthru = PackagePassthru (HashMap Text Text)
+  deriving newtype (Semigroup, Monoid)
+
 -- | A package is defined with:
 --
 -- 1. its name
 -- 2. how to track its version
 -- 3. how to fetch it as we have the version
--- 4. optional file paths to extract (dump to generated nix expr)
--- 5. @Cargo.lock@ path (if it's a rust package)
+-- 4. optional file paths to extract (dump to shake dir)
+-- 5. optional @Cargo.lock@ path (if it's a rust package)
+-- 6. an optional pass through map
 --
 -- /INVARIANT: 'Version' passed to 'PackageFetcher' MUST be used textually,/
 -- /i.e. can only be concatenated with other strings,/
@@ -266,7 +271,8 @@ data Package = Package
     _pversion :: NvcheckerQ,
     _pfetcher :: PackageFetcher,
     _pextract :: Maybe PackageExtractSrc,
-    _pcargo :: Maybe PackageCargoFilePath
+    _pcargo :: Maybe PackageCargoFilePath,
+    _ppassthru :: PackagePassthru
   }
 
 -- | Package key is the name of a package.


### PR DESCRIPTION
Now

```toml
[vscode-LiveServer]
src.openvsx = "ritwickdey.LiveServer"
fetch.openvsx = "ritwickdey.LiveServer"
passthru = { publisher = "ritwickdey", name = "LiveServer" }
```

produces

```nix
{ fetchgit, fetchurl }:
{
  vscode-LiveServer = {
    pname = "vscode-LiveServer";
    version = "5.6.1";
    src = fetchurl {
      sha256 = "077arf3hsn1yb8xdhlrax5gf93ljww78irv4gm8ffmsqvcr1kws0";
      url = "https://ritwickdey.gallery.vsassets.io/_apis/public/gallery/publisher/ritwickdey/extension/LiveServer/5.6.1/assetbyname/Microsoft.VisualStudio.Services.VSIXPackage";
    };
    name = "LiveServer";
    publisher = "ritwickdey";
  };
}
```

> ~~There is no way to check the equality over version sources and fetchers, so If you change either of them in a package,
you will need to rebuild everything, i.e. run `nvfetcher clean` to remove shake databsae, to make sure that
our build system works correctly. We could automate this process, for example,
calculate the hash of the configuration file and bump `shakeVersion` to trigger the rebuild.
However, this shouldn't happen frequently and we want to minimize the changes, so it's left for you to do manually.~~

Also, by separating `PackageKey` and using [`alwaysRerun`](https://hackage.haskell.org/package/shake-0.19.5/docs/Development-Shake.html#v:alwaysRerun) on the `Core` rule, we no longer have such limitations!

/cc @NickCao


