### PR TITLE
fix missing ";" for Cargo.lock

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -32,6 +32,9 @@ jobs:
     - name: Run CLI with nvfetcher_example.toml
       run : nix shell --command nvfetcher --config nvfetcher_example.toml
 
+    - name: Run generated.nix syntax check
+      run : nix eval -f _sources/generated.nix
+
     - name: Cleanup
       run: rm -r _sources sources.nix
 

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -75,7 +75,7 @@ coreRules = do
                           -- write extracted files to shake dir
                           -- and read them in nix using 'builtins.readFile'
                           writeFile' (shakeDir </> path) (T.unpack v)
-                          pure $ toNixExpr k <> " = builtins.readFile ./" <> T.pack path
+                          pure $ toNixExpr k <> " = builtins.readFile ./" <> T.pack path <> ";"
                         | (k, v) <- result,
                           let path =
                                 T.unpack _pname


### PR DESCRIPTION
r: syntax error, unexpected '}', expecting ';'

       at /nix/store/zkvj6av2wjd3bjwj16yfxq971jcd72z7-source/nix/_sources/generated.nix:28:3:

           27|     "rust_src/Cargo.lock" = builtins.readFile ./emacs-ng-cargo-79390ea31d003bbda7916849a205f1f76eb13154/rust_src/Cargo.lock
           28|   };
             |   ^
           29|   fd = {
(use '--show-trace' to show detailed location information)
