### PR TITLE
Replace outputPath with buildDir

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,7 +36,7 @@ jobs:
       run : nix eval -f _sources/generated.nix
 
     - name: Cleanup
-      run: rm -r _sources sources.nix
+      run: rm -r _sources
 
     - name: Run Main_example.hs
       run: nix develop .\#ghcWithNvfetcher --command runghc Main_example.hs

--- a/README.md
+++ b/README.md
@@ -54,12 +54,8 @@ it can create `sources.nix` like:
 ```
 
 We tell nvfetcher how to get the latest version number of packages and how to fetch their sources given version numbers,
-and nvfetcher will help us keep their version and prefetched SHA256 sums up-to-date, stored in `sources.nix`.
-Shake will handle necessary rebuilds -- we check versions of packages during each run, but only prefetch them when needed.
-
-
-`sources.nix` is a symlink of `_sources/generated.nix`, which means that the "build" results produced by `nvfetcher` are under `_sources`,
-so you have to keep this directory for further use.
+and nvfetcher will help us keep their version and prefetched SHA256 sums up-to-date, stored in `_sources/generated.nix`.
+Shake will handle necessary rebuilds as long as you keep `_sources` directory -- we check versions of packages during each run, but only prefetch them when needed.
 
 ### Live examples
 
@@ -107,7 +103,8 @@ To run nvfetcher as a CLI program, you'll need to provide package sources define
 Available options:
   --version                Show version
   --help                   Show this help text
-  -o,--output FILE         Path to output nix file (default: "sources.nix")
+  -o,--build-dir FILE      Directory that nvfetcher puts artifacts to
+                           (default: "_sources")
   --commit-changes         `git commit` changes in this run (with shake db)
   -l,--changelog FILE      Dump version changes to a file
   -j NUM                   Number of threads (0: detected number of processors)
@@ -116,7 +113,6 @@ Available options:
                            nix-instantiate, etc.) (default: 3)
   -t,--timing              Show build time
   -v,--verbose             Verbose mode
-  --no-output              Don't symlink generated.nix to the output path
   TARGET                   Two targets are available: 1.build 2.clean
                            (default: "build")
   -c,--config FILE         Path to nvfetcher TOML config

--- a/src/NvFetcher/Options.hs
+++ b/src/NvFetcher/Options.hs
@@ -36,7 +36,7 @@ cliOptionsParser =
     <$> strOption
       ( long "build-dir"
           <> short 'o'
-          <> metavar "FILE"
+          <> metavar "DIR"
           <> help "Directory that nvfetcher puts artifacts to"
           <> showDefault
           <> value "_sources"

--- a/src/NvFetcher/Options.hs
+++ b/src/NvFetcher/Options.hs
@@ -19,14 +19,13 @@ import qualified Paths_nvfetcher as Paths
 
 -- | Options for nvfetcher CLI
 data CLIOptions = CLIOptions
-  { outputPath :: FilePath,
+  { buildDir :: FilePath,
     commit :: Bool,
     logPath :: Maybe FilePath,
     threads :: Int,
     retries :: Int,
     timing :: Bool,
     verbose :: Bool,
-    noOutput :: Bool,
     target :: String
   }
   deriving (Show)
@@ -35,13 +34,13 @@ cliOptionsParser :: Parser CLIOptions
 cliOptionsParser =
   CLIOptions
     <$> strOption
-      ( long "output"
+      ( long "build-dir"
           <> short 'o'
           <> metavar "FILE"
-          <> help "Path to output nix file"
+          <> help "Directory that nvfetcher puts artifacts to"
           <> showDefault
-          <> value "sources.nix"
-          <> completer (bashCompleter "file")
+          <> value "_sources"
+          <> completer (bashCompleter "directory")
       )
     <*> switch
       ( long "commit-changes"
@@ -75,7 +74,6 @@ cliOptionsParser =
       )
     <*> switch (long "timing" <> short 't' <> help "Show build time")
     <*> switch (long "verbose" <> short 'v' <> help "Verbose mode")
-    <*> switch (long "no-output" <> help "Don't symlink generated.nix to the output path")
     <*> strArgument
       ( metavar "TARGET"
           <> help "Two targets are available: 1.build  2.clean"
@@ -93,13 +91,8 @@ getCLIOptions parser = do
   (opts, ()) <-
     simpleOptions
       version
-      "nvfetcher - generate nix sources expr for the latest version of packages"
-      ( unlines
-          [ "It's important to keep _sources dir.",
-            "If you change any field of an existing package, you may have to run target \"clean\" to invalidate the databse,",
-            "making sure the consistency of our build system."
-          ]
-      )
+      "nvfetcher"
+      "generate nix sources expr for the latest version of packages"
       parser
       empty
   pure opts

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -51,13 +51,13 @@ spec = aroundShake' (Map.singleton fakePackageKey fakePackage) $
       runNvcheckerRule (Manual "Meow") `shouldReturnJust` Version "Meow"
 
     specifyChan "openvsx" $
-      runNvcheckerRule (OpenVsx "usernamehw" "indent-one-space") `shouldReturnJust` Version "0.2.6"
+      runNvcheckerRule (OpenVsx "usernamehw" "indent-one-space") `shouldReturnJust` Version "0.2.7"
 
     specifyChan "repology" $
       runNvcheckerRule (Repology "ssed" "aur") `shouldReturnJust` Version "3.62"
 
     specifyChan "vsmarketplace" $
-      runNvcheckerRule (VscodeMarketplace "usernamehw" "indent-one-space") `shouldReturnJust` Version "0.2.6"
+      runNvcheckerRule (VscodeMarketplace "usernamehw" "indent-one-space") `shouldReturnJust` Version "0.2.8"
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #15

* Remove option `--output`
* Remove option `--no-output`
* Add option `build-dir` to set shake dir (default: `_sources`)