### PR TITLE
Support pinning a package

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ extracting the lock file to build and calculating `cargoLock.outputHashes`, as l
 
   * `passthru = { k1 = "v1", k2 = "v2", ... }`
 
+#### Pinned
+
+If a package is pinned, we call nvchecker to check the new version iff there's no existing version.
+
+* `pinned = true`
+
 ### Haskell library
 
 nvfetcher itsetlf is a Haskell library as well, whereas the CLI program is just a trivial wrapper of the library.

--- a/app/Config.hs
+++ b/app/Config.hs
@@ -39,7 +39,8 @@ data PackageConfig = PackageConfig
     pcExtractFiles :: Maybe PackageExtractSrc,
     pcCargoLockPath :: Maybe PackageCargoFilePath,
     pcNvcheckerOptions :: NvcheckerOptions,
-    pcPassthru :: PackagePassthru
+    pcPassthru :: PackagePassthru,
+    pcUseStale :: UseStaleVersion
   }
 
 toPackage :: PackageKey -> PackageConfig -> Package
@@ -51,6 +52,7 @@ toPackage k PackageConfig {..} =
     pcExtractFiles
     pcCargoLockPath
     pcPassthru
+    pcUseStale
 
 packageConfigCodec :: TomlCodec PackageConfig
 packageConfigCodec =
@@ -61,6 +63,7 @@ packageConfigCodec =
     <*> cargoLockPathCodec .= pcCargoLockPath
     <*> nvcheckerOptionsCodec .= pcNvcheckerOptions
     <*> passthruCodec .= pcPassthru
+    <*> pinnedCodec .= pcUseStale
 
 --------------------------------------------------------------------------------
 
@@ -83,3 +86,6 @@ nvcheckerOptionsCodec =
 
 passthruCodec :: TomlCodec PackagePassthru
 passthruCodec = diwrap $ tableHashMap _KeyText text "passthru"
+
+pinnedCodec :: TomlCodec UseStaleVersion
+pinnedCodec = dimap (Just . coerce) (maybe (UseStaleVersion False) coerce) $ dioptional $ bool "pinned"

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -61,7 +61,7 @@ coreRules = do
             -- it's important to always rerun
             -- since the package definition is not tracked at all
             alwaysRerun
-            (NvcheckerA version mOldV) <- checkVersion versionSource options pkg
+            (NvcheckerA version mOldV _isStale) <- checkVersion versionSource options pkg
             prefetched <- prefetch $ _pfetcher version
             shakeDir <- getShakeDir
             -- extract src

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -2,20 +2,28 @@
 
 module CheckVersionSpec where
 
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Reader
 import Data.Coerce (coerce)
 import Data.Default (def)
 import qualified Data.Map.Strict as Map
+import qualified Data.Text as T
 import Lens.Micro
 import NvFetcher.Nvchecker
 import NvFetcher.Types
 import NvFetcher.Types.Lens
+import System.IO.Extra (newTempFile)
 import Test.Hspec
 import Utils
 
--- | We need a fakePackageKey here; otherwise the nvchecker rule would be cutoff
 spec :: Spec
-spec = aroundShake' (Map.singleton fakePackageKey fakePackage) $
+spec = do
+  versionSourcesSpec
+  useStaleSpec
+
+-- | We need a fakePackageKey here; otherwise the nvchecker rule would be cutoff
+versionSourcesSpec :: Spec
+versionSourcesSpec = aroundShake' (Map.singleton fakePackageKey fakePackage) $
   describe "nvchecker" $ do
     specifyChan "pypi" $
       runNvcheckerRule (Pypi "example") `shouldReturnJust` Version "0.1.0"
@@ -64,8 +72,31 @@ spec = aroundShake' (Map.singleton fakePackageKey fakePackage) $
 
 --------------------------------------------------------------------------------
 
+-- | We need a new shake session for checking useStale working
+useStaleSpec :: Spec
+useStaleSpec = aroundShake' (Map.singleton fakePackageKey pinnedPackage) $
+  describe "useStale" $ do
+    (temp, cleanup) <- runIO newTempFile
+
+    let versionSource = Cmd $ "cat " <> T.pack temp
+
+    specifyChan "needs run" $ do
+      liftIO $ writeFile temp "Meow"
+      runNvcheckerRule' versionSource `shouldReturnJust` NvcheckerA {nvNow = "Meow", nvOld = Nothing, nvStale = False}
+
+    specifyChan "stale" $ do
+      liftIO $ writeFile temp "Bark"
+      runNvcheckerRule' versionSource `shouldReturnJust` NvcheckerA {nvNow = "Meow", nvOld = Nothing, nvStale = True}
+
+    runIO cleanup
+
+--------------------------------------------------------------------------------
+
 runNvcheckerRule :: VersionSource -> ReaderT ActionQueue IO (Maybe Version)
-runNvcheckerRule v = runActionChan $ nvNow <$> checkVersion v def fakePackageKey
+runNvcheckerRule v = fmap nvNow <$> runNvcheckerRule' v
+
+runNvcheckerRule' :: VersionSource -> ReaderT ActionQueue IO (Maybe NvcheckerA)
+runNvcheckerRule' v = runActionChan $ checkVersion v def fakePackageKey
 
 fakePackageKey :: PackageKey
 fakePackageKey = PackageKey "a-fake-package"
@@ -78,5 +109,18 @@ fakePackage =
       _pfetcher = undefined,
       _pcargo = undefined,
       _pextract = undefined,
-      _ppassthru = undefined
+      _ppassthru = undefined,
+      _ppinned = UseStaleVersion False
+    }
+
+pinnedPackage :: Package
+pinnedPackage =
+  Package
+    { _pname = coerce fakePackageKey,
+      _pversion = undefined,
+      _pfetcher = undefined,
+      _pcargo = undefined,
+      _pextract = undefined,
+      _ppassthru = undefined,
+      _ppinned = UseStaleVersion True
     }


### PR DESCRIPTION
Now one can "pin" a package:

```toml
[feeluown-core]
src.pypi = "feeluown"
fetch.pypi = "feeluown"
pinned = true
```

If we have a version of the package, nvchecker won't run for checking new versions.