### PR TITLE
Really don't cache generated nix expr

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,6 +16,9 @@ jobs:
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable
 
+    - name: Replace git://github.com/ with https://github.com/
+      run: git config --global url."https://github.com/".insteadOf git://github.com/
+
     - name: Run Nix Flake Check
       run: nix flake check
 

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,9 +16,6 @@ jobs:
           experimental-features = nix-command flakes
         nix_path: nixpkgs=channel:nixos-unstable
 
-    - name: Replace git://github.com/ with https://github.com/
-      run: git config --global url."https://github.com/".insteadOf git://github.com/
-
     - name: Run Nix Flake Check
       run: nix flake check
 

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -18,13 +18,13 @@ module NvFetcher.Core
   )
 where
 
-import Control.Monad (void)
 import Data.Coerce (coerce)
 import qualified Data.HashMap.Strict as HMap
 import Data.Text (Text)
 import qualified Data.Text as T
 import Development.Shake
 import Development.Shake.FilePath
+import Development.Shake.Rule
 import NeatInterpolation (trimming)
 import NvFetcher.ExtractSrc
 import NvFetcher.FetchRustGitDeps
@@ -43,80 +43,82 @@ coreRules = do
   prefetchRule
   extractSrcRule
   fetchRustGitDepsRule
-  void $
-    addOracle $ \(WithPackageKey (Core, pkg)) -> do
-      -- it's important to always rerun
-      -- since the package definition is not tracked at all
-      alwaysRerun
-      lookupPackage pkg >>= \case
-        Nothing -> fail $ "Unkown package key: " <> show pkg
-        Just
-          Package
-            { _pversion = CheckVersion versionSource options,
-              _ppassthru = PackagePassthru passthruMap,
-              ..
-            } -> do
-            (NvcheckerResult version mOldV _isStale) <- checkVersion versionSource options pkg
-            prefetched <- prefetch $ _pfetcher version
-            shakeDir <- getShakeDir
-            -- extract src
-            appending1 <-
-              case _pextract of
-                Just (PackageExtractSrc extract) -> do
-                  result <- HMap.toList <$> extractSrcs prefetched extract
-                  T.unlines
-                    <$> sequence
-                      [ do
-                          -- write extracted files to shake dir
-                          -- and read them in nix using 'builtins.readFile'
-                          writeFile' (shakeDir </> path) (T.unpack v)
-                          pure $ toNixExpr k <> " = builtins.readFile ./" <> T.pack path <> ";"
-                        | (k, v) <- result,
-                          let path =
-                                T.unpack _pname
-                                  <> "-"
-                                  <> T.unpack (coerce version)
-                                  </> k
-                      ]
-                _ -> pure ""
-            -- cargo lock
-            appending2 <-
-              case _pcargo of
-                Just (PackageCargoFilePath lockPath) -> do
-                  (_, lockData) <- head . HMap.toList <$> extractSrc prefetched lockPath
-                  result <- fetchRustGitDeps prefetched lockPath
-                  let body = T.unlines [quote k <> " = " <> coerce (quote $ coerce v) <> ";" | (k, v) <- HMap.toList result]
-                      lockPath' =
-                        T.unpack _pname
-                          <> "-"
-                          <> T.unpack (coerce version)
-                          </> lockPath
-                      lockPathNix = "./" <> T.pack lockPath'
-                  -- similar to extract src, write lock file to shake dir
-                  writeFile' (shakeDir </> lockPath') $ T.unpack lockData
-                  pure
-                    [trimming|
-                  cargoLock = {
-                    lockFile = $lockPathNix;
-                    outputHashes = {
-                      $body
+  addBuiltinRule noLint noIdentity $ \(WithPackageKey (Core, pkg)) _ _ -> do
+    -- it's important to always rerun
+    -- since the package definition is not tracked at all
+    alwaysRerun
+    lookupPackage pkg >>= \case
+      Nothing -> fail $ "Unkown package key: " <> show pkg
+      Just
+        Package
+          { _pversion = CheckVersion versionSource options,
+            _ppassthru = PackagePassthru passthruMap,
+            ..
+          } -> do
+          (NvcheckerResult version mOldV _isStale) <- checkVersion versionSource options pkg
+          prefetched <- prefetch $ _pfetcher version
+          shakeDir <- getShakeDir
+          -- extract src
+          appending1 <-
+            case _pextract of
+              Just (PackageExtractSrc extract) -> do
+                result <- HMap.toList <$> extractSrcs prefetched extract
+                T.unlines
+                  <$> sequence
+                    [ do
+                        -- write extracted files to shake dir
+                        -- and read them in nix using 'builtins.readFile'
+                        writeFile' (shakeDir </> path) (T.unpack v)
+                        pure $ toNixExpr k <> " = builtins.readFile ./" <> T.pack path <> ";"
+                      | (k, v) <- result,
+                        let path =
+                              T.unpack _pname
+                                <> "-"
+                                <> T.unpack (coerce version)
+                                </> k
+                    ]
+              _ -> pure ""
+          -- cargo lock
+          appending2 <-
+            case _pcargo of
+              Just (PackageCargoFilePath lockPath) -> do
+                (_, lockData) <- head . HMap.toList <$> extractSrc prefetched lockPath
+                result <- fetchRustGitDeps prefetched lockPath
+                let body = T.unlines [quote k <> " = " <> coerce (quote $ coerce v) <> ";" | (k, v) <- HMap.toList result]
+                    lockPath' =
+                      T.unpack _pname
+                        <> "-"
+                        <> T.unpack (coerce version)
+                        </> lockPath
+                    lockPathNix = "./" <> T.pack lockPath'
+                -- similar to extract src, write lock file to shake dir
+                writeFile' (shakeDir </> lockPath') $ T.unpack lockData
+                pure
+                  [trimming|
+                    cargoLock = {
+                      lockFile = $lockPathNix;
+                      outputHashes = {
+                        $body
+                      };
                     };
-                  };
-                |]
-                _ -> pure ""
-            -- passthru
-            let appending3 = T.unlines [k <> " = " <> v <> ";" | (k, quote -> v) <- HMap.toList passthruMap]
+                  |]
+              _ -> pure ""
+          -- passthru
+          let appending3 = T.unlines [k <> " = " <> v <> ";" | (k, quote -> v) <- HMap.toList passthruMap]
 
-            -- update changelog
-            case mOldV of
-              Nothing ->
-                recordVersionChange _pname Nothing version
-              Just old
-                | old /= version ->
-                  recordVersionChange _pname (Just old) version
-              _ -> pure ()
+          -- update changelog
+          case mOldV of
+            Nothing ->
+              recordVersionChange _pname Nothing version
+            Just old
+              | old /= version ->
+                recordVersionChange _pname (Just old) version
+            _ -> pure ()
 
-            pure $ gen _pname version prefetched $ appending1 <> appending2 <> appending3
+          let result = gen _pname version prefetched $ appending1 <> appending2 <> appending3
+          -- Since we don't save the previous result, we are not able to know if the result changes
+          -- Depending on this rule leads to RunDependenciesChanged
+          pure $ RunResult ChangedRecomputeDiff mempty result
 
 -- | Run the core rule.
 -- Given a 'PackageKey', run "NvFetcher.Nvchecker", "NvFetcher.NixFetcher"
@@ -147,7 +149,7 @@ coreRules = do
 --   };
 -- @
 generateNixSourceExpr :: PackageKey -> Action NixExpr
-generateNixSourceExpr k = askOracle $ WithPackageKey (Core, k)
+generateNixSourceExpr k = apply1 $ WithPackageKey (Core, k)
 
 gen :: PackageName -> Version -> NixFetcher Fetched -> Text -> Text
 gen name (coerce -> ver) (toNixExpr -> srcP) appending =

--- a/test/PrefetchSpec.hs
+++ b/test/PrefetchSpec.hs
@@ -25,8 +25,8 @@ spec = aroundShake $
         `shouldReturnJust` Checksum "sha256-h6dBBlsnl6Q7vHUjrnezmjn3EsZHF+Q35BLt1SARuO4="
 
     specifyChan "git" $
-      runPrefetchRule (gitFetcher "https://gitlab.com/gitlab-org/gitlab-test.git" "ddd0f15ae83993f5cb66a927a28673882e99100b")
-        `shouldReturnJust` Checksum "sha256-LHRlNq6YKUXAKjr2m+BOmzK7veLadIUk998ycxahVn4="
+      runPrefetchRule (gitFetcher "https://github.com/git-up/test-repo-submodules" "5a1dfa807759c39e3df891b6b46dfb2cf776c6ef")
+        `shouldReturnJust` Checksum "sha256-wCo1YobyatxSOE85xQNSJw6jvufghFNHlZl4ToQjRHA="
 
     specifyChan "github" $
       runPrefetchRule (gitHubFetcher ("harry-sanabria", "ReleaseTestRepo") "release3")


### PR DESCRIPTION
It turns out that results of rules defined by `addOracle` will be cached once for determining if they are changed.