### PR TITLE
Internalize shake database

### DIFF
--- a/Main_example.hs
+++ b/Main_example.hs
@@ -28,11 +28,11 @@ packageSet = do
       `sourceGit` "https://github.com/berberman/nvfetcher"
       `fetchGitHub` ("berberman", "nvfetcher")
 
-  define $
-    package "vim"
-      `sourceWebpage` ("http://ftp.vim.org/pub/vim/patches/7.3/", "7\\.3\\.\\d+", id)
-      `fetchGitHub` ("vim", "vim")
-      `tweakVersion` (\v -> v & fromPattern ?~ "(.+)" & toPattern ?~ "v\\1")
+  -- define $
+  --   package "vim"
+  --     `sourceWebpage` ("http://ftp.vim.org/pub/vim/patches/7.3/", "7\\.3\\.\\d+", id)
+  --     `fetchGitHub` ("vim", "vim")
+  --     `tweakVersion` (\v -> v & fromPattern ?~ "(.+)" & toPattern ?~ "v\\1")
 
   define $
     package "rust-git-dependency-example"

--- a/README.md
+++ b/README.md
@@ -14,58 +14,63 @@ For example, feeding the following configuration to`nvfetcher`:
 
 ```toml
 # nvfetcher.toml
-[feeluown-core]
+[feeluown]
 src.pypi = "feeluown"
 fetch.pypi = "feeluown"
-
-[qliveplayer]
-src.github = "THMonster/QLivePlayer"
-fetch.github = "THMonster/QLivePlayer"
-git.fetchSubmodules = true
 ```
 
-it can create `sources.nix` like:
+it will create `_sources/generated.nix`:
 
 ```nix
-# sources.nix
-{ fetchgit, fetchurl }:
+{ fetchgit, fetchurl, fetchFromGitHub }:
 {
-  feeluown-core = {
-    pname = "feeluown-core";
-    version = "3.7.7";
+  feeluown = {
+    pname = "feeluown";
+    version = "3.8.2";
     src = fetchurl {
-      sha256 = "06d3j39ff9znqxkhp9ly81lcgajkhg30hyqxy2809yn23xixg3x2";
-      url = "https://pypi.io/packages/source/f/feeluown/feeluown-3.7.7.tar.gz";
-    };
-  };
-  qliveplayer = {
-    pname = "qliveplayer";
-    version = "3.22.1";
-    src = fetchgit {
-      url = "https://github.com/THMonster/QLivePlayer";
-      rev = "3.22.1";
-      fetchSubmodules = true;
-      deepClone = false;
-      leaveDotGit = false;
-      sha256 = "00zqg28q5xrbgql0kclgkhd15fc02qzsrvi0qg8lg3qf8a53v263";
+      url = "https://pypi.io/packages/source/f/feeluown/feeluown-3.8.2.tar.gz";
+      sha256 = "sha256-V2yzpkmjRkipZOvQGB2mYRhiiEly6QPrTOMJ7BmyWBQ=";
     };
   };
 }
 ```
 
+and `_sources/generated.json`:
+
+```json
+{
+    "feeluown": {
+        "pinned": false,
+        "cargoLock": null,
+        "name": "feeluown-core",
+        "version": "3.8.2",
+        "passthru": null,
+        "src": {
+            "url": "https://pypi.io/packages/source/f/feeluown/feeluown-3.8.2.tar.gz",
+            "name": null,
+            "type": "url",
+            "sha256": "sha256-V2yzpkmjRkipZOvQGB2mYRhiiEly6QPrTOMJ7BmyWBQ="
+        },
+        "extract": null,
+        "rustGitDeps": null
+    }
+}
+```
+
 We tell nvfetcher how to get the latest version number of packages and how to fetch their sources given version numbers,
-and nvfetcher will help us keep their version and prefetched SHA256 sums up-to-date, stored in `_sources/generated.nix`.
-Shake will handle necessary rebuilds as long as you keep `_sources` directory -- we check versions of packages during each run, but only prefetch them when needed.
+and nvfetcher will help us keep their version and prefetched SHA256 sums up-to-date, producing ready-to-use nix expressions in `_sources/generated.nix`.
+Nvfetcher reads `generated.json` to produce version change message, such as `feeluown: 3.8.1 → 3.8.2`.
+We always check versions of packages during each run, but only do prefetch and further operations when needed.
 
 ### Live examples
 
 How to use the generated sources file? Here are several examples:
 
-* [DevOS](https://github.com/divnix/devos/tree/main/pkgs) - Packages are defined in TOML
+* [DevOS](https://github.com/divnix/devos/tree/main/pkgs)
 
-* My [flakes repo](https://github.com/berberman/flakes) - Packages are defined in eDSL
+* My [flakes repo](https://github.com/berberman/flakes)
 
-* Nick Cao's [flakes repo](https://gitlab.com/NickCao/flakes/-/tree/master/pkgs) - Packages are defined in TOML
+* Nick Cao's [flakes repo](https://gitlab.com/NickCao/flakes/-/tree/master/pkgs)
 
 ## Installation
 
@@ -105,7 +110,8 @@ Available options:
   --help                   Show this help text
   -o,--build-dir DIR       Directory that nvfetcher puts artifacts to
                            (default: "_sources")
-  --commit-changes         `git commit` changes in this run (with shake db)
+  --commit-changes         `git commit` build dir with version changes as commit
+                           message
   -l,--changelog FILE      Dump version changes to a file
   -j NUM                   Number of threads (0: detected number of processors)
                            (default: 0)

--- a/nvfetcher_example.toml
+++ b/nvfetcher_example.toml
@@ -25,13 +25,13 @@ src.github_tag = "gcc-mirror/gcc"
 src.include_regex = "releases/gcc-10.*"
 fetch.github = "gcc-mirror/gcc"
 
-[vim]
-src.webpage = "http://ftp.vim.org/pub/vim/patches/7.3/"
-src.regex = "7\\.3\\.\\d+"
-fetch.github = "vim/vim"
-# nvchecker global options, which adds prefix `v` to the version number  
-src.from_pattern = "(.+)"
-src.to_pattern = "v\\1"
+# [vim]
+# src.webpage = "http://ftp.vim.org/pub/vim/patches/7.3/"
+# src.regex = "7\\.3\\.\\d+"
+# fetch.github = "vim/vim"
+# # nvchecker global options, which adds prefix `v` to the version number  
+# src.from_pattern = "(.+)"
+# src.to_pattern = "v\\1"
 
 [fd]
 src.github = "sharkdp/fd"

--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -216,11 +216,9 @@ mainRules Args {..} = do
     allKeys <- getAllPackageKeys
     results <- parallel $ runPackage <$> allKeys
     -- Record removed packages to version changes
-    getShakeExtras
-      >>= ( \oldPkgs -> forM_ (Map.keys oldPkgs \\ allKeys) $
-              \pkg -> recordVersionChange (coerce pkg) (oldPkgs Map.!? pkg) "∅"
-          )
-        . lastVersions
+    getAllOnDiskVersions
+      >>= \oldPkgs -> forM_ (Map.keys oldPkgs \\ allKeys) $
+        \pkg -> recordVersionChange (coerce pkg) (oldPkgs Map.!? pkg) "∅"
     getVersionChanges >>= \changes ->
       if null changes
         then putInfo "Up to date"

--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
@@ -44,17 +46,21 @@ module NvFetcher
     runNvFetcher',
     runNvFetcherNoCLI,
     applyCliOptions,
+    parseLastVersions,
     module NvFetcher.PackageSet,
     module NvFetcher.Types,
     module NvFetcher.Types.ShakeExtras,
   )
 where
 
-import Control.Monad.Extra (when, whenJust)
+import Control.Monad.Extra (forM_, when, whenJust)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encode.Pretty as A
+import qualified Data.Aeson.Types as A
 import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.List ((\\))
 import qualified Data.Map.Strict as Map
+import Data.Maybe (catMaybes, fromMaybe)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Development.Shake
@@ -68,7 +74,8 @@ import NvFetcher.Options
 import NvFetcher.PackageSet
 import NvFetcher.Types
 import NvFetcher.Types.ShakeExtras
-import NvFetcher.Utils (getShakeDir)
+import NvFetcher.Utils (getDataDir)
+import qualified System.Directory.Extra as D
 import Text.Regex.TDFA ((=~))
 
 -- | Arguments for running nvfetcher
@@ -77,7 +84,7 @@ data Args = Args
     argShakeOptions :: ShakeOptions,
     -- | Build target
     argTarget :: String,
-    -- | Shake dir
+    -- | Build dir
     argBuildDir :: FilePath,
     -- | Custom rules
     argRules :: Rules (),
@@ -133,8 +140,7 @@ applyCliOptions args CLIOptions {..} =
         (argShakeOptions defaultArgs)
           { shakeTimings = timing,
             shakeVerbosity = if verbose then Verbose else Info,
-            shakeThreads = threads,
-            shakeFiles = buildDir
+            shakeThreads = threads
           },
       argFilterRegex = pkgNameFilter
     }
@@ -153,17 +159,36 @@ commitChanges = do
         [] -> Nothing
   whenJust commitMsg $ \msg -> do
     putInfo "Commiting changes"
-    getShakeDir >>= \dir -> command_ [] "git" ["add", dir]
+    getBuildDir >>= \dir -> command_ [] "git" ["add", dir]
     command_ [] "git" ["commit", "-m", msg]
+
+-- | @Parse generated.nix@
+parseLastVersions :: FilePath -> IO (Maybe (Map.Map PackageKey Version))
+parseLastVersions jsonFile =
+  D.doesFileExist jsonFile >>= \case
+    True -> do
+      objs <- A.decodeFileStrict' jsonFile
+      pure $
+        flip fmap objs $
+          ( \xs ->
+              Map.fromList
+                . catMaybes
+                $ [(PackageKey k,) <$> A.parseMaybe (A..: "version") obj | (k, obj) <- xs]
+          )
+            . Map.toList
+    _ -> pure mempty
 
 -- | Entry point of nvfetcher
 runNvFetcherNoCLI :: Args -> PackageSet () -> IO ()
 runNvFetcherNoCLI args@Args {..} packageSet = do
   pkgs <- Map.map pinIfUnmatch <$> runPackageSet packageSet
-  shakeExtras <- initShakeExtras pkgs argRetries
+  lastVersions <- parseLastVersions $ argBuildDir </> "generated.json"
+  shakeExtras <- initShakeExtras pkgs argRetries argBuildDir $ fromMaybe mempty lastVersions
+  shakeDir <- getDataDir
   let opts =
         argShakeOptions
-          { shakeExtra = addShakeExtra shakeExtras (shakeExtra argShakeOptions)
+          { shakeFiles = shakeDir,
+            shakeExtra = addShakeExtra shakeExtras (shakeExtra argShakeOptions)
           }
       rules = mainRules args
   shake opts $ want [argTarget] >> rules
@@ -184,21 +209,27 @@ runNvFetcherNoCLI args@Args {..} packageSet = do
 mainRules :: Args -> Rules ()
 mainRules Args {..} = do
   "clean" ~> do
-    getShakeDir >>= flip removeFilesAfter ["//*"]
+    getBuildDir >>= flip removeFilesAfter ["//*"]
     argActionAfterClean
 
   "build" ~> do
     allKeys <- getAllPackageKeys
     results <- parallel $ runPackage <$> allKeys
+    -- Record removed packages to version changes
+    getShakeExtras
+      >>= ( \oldPkgs -> forM_ (Map.keys oldPkgs \\ allKeys) $
+              \pkg -> recordVersionChange (coerce pkg) (oldPkgs Map.!? pkg) "∅"
+          )
+        . lastVersions
     getVersionChanges >>= \changes ->
       if null changes
         then putInfo "Up to date"
         else do
           putInfo "Changes:"
           putInfo $ unlines $ show <$> changes
-    shakeDir <- getShakeDir
-    let generatedNixPath = shakeDir </> "generated.nix"
-        generatedJSONPath = shakeDir </> "generated.json"
+    buildDir <- getBuildDir
+    let generatedNixPath = buildDir </> "generated.nix"
+        generatedJSONPath = buildDir </> "generated.json"
     putVerbose $ "Generating " <> generatedNixPath
     writeFileChanged generatedNixPath $ T.unpack $ srouces (T.unlines $ toNixExpr <$> results) <> "\n"
     putVerbose $ "Generating " <> generatedJSONPath

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -27,7 +27,6 @@ import NvFetcher.NixFetcher
 import NvFetcher.Nvchecker
 import NvFetcher.Types
 import NvFetcher.Types.ShakeExtras
-import NvFetcher.Utils
 
 -- | The core rule of nvchecker.
 -- all rules are wired here.
@@ -52,7 +51,7 @@ coreRules = do
           } -> do
           _prversion@(NvcheckerResult version mOldV _isStale) <- checkVersion versionSource options pkg
           _prfetched <- prefetch $ _pfetcher version
-          shakeDir <- getShakeDir
+          buildDir <- getBuildDir
           -- extract src
           _prextract <-
             case _pextract of
@@ -61,9 +60,9 @@ coreRules = do
                 Just . HMap.fromList
                   <$> sequence
                     [ do
-                        -- write extracted files to shake dir
+                        -- write extracted files to build dir
                         -- and read them in nix using 'builtins.readFile'
-                        writeFile' (shakeDir </> path) (T.unpack v)
+                        writeFile' (buildDir </> path) (T.unpack v)
                         pure (k, T.pack path)
                       | (k, v) <- result,
                         let path =
@@ -86,8 +85,8 @@ coreRules = do
                         <> T.unpack (coerce version)
                         </> lockPath
                     lockPathNix = "./" <> T.pack lockPath'
-                -- similar to extract src, write lock file to shake dir
-                writeFile' (shakeDir </> lockPath') $ T.unpack lockData
+                -- similar to extract src, write lock file to build dir
+                writeFile' (buildDir </> lockPath') $ T.unpack lockData
                 pure (Just lockPathNix, Just result)
               _ -> pure (Nothing, Nothing)
 

--- a/src/NvFetcher/Options.hs
+++ b/src/NvFetcher/Options.hs
@@ -45,7 +45,7 @@ cliOptionsParser =
       )
     <*> switch
       ( long "commit-changes"
-          <> help "`git commit` changes in this run (with shake db)"
+          <> help "`git commit` build dir with version changes as commit message"
       )
     <*> optional
       ( strOption

--- a/src/NvFetcher/Types.hs
+++ b/src/NvFetcher/Types.hs
@@ -176,7 +176,8 @@ data NvcheckerResult = NvcheckerResult
   { nvNow :: Version,
     -- | shake restores it from last run
     nvOld :: Maybe Version,
-    -- | stale means even 'nvNow' comes from shake, where we actually didn't run nvchecker
+    -- | stale means even 'nvNow' comes from json file or last run
+    -- and we actually didn't run nvchecker this time. 'nvOld' will be 'Nothing' in this case.
     nvStale :: Bool
   }
   deriving (Show, Typeable, Eq, Generic, Hashable, Binary, NFData)
@@ -322,7 +323,8 @@ newtype PackagePassthru = PackagePassthru (HashMap Text Text)
 
 -- | This bool value means whether or not to use stale value.
 -- Using stale value indicates that we will /NOT/ check for new versions if
--- there is a known version in shake. Normally you don't want a stale version
+-- there is a known version recoverd from json file or last use of the rule.
+-- Normally you don't want a stale version
 -- unless you need pin a package.
 newtype UseStaleVersion = UseStaleVersion Bool
   deriving newtype (Eq, Show, Ord)
@@ -334,7 +336,7 @@ newtype UseStaleVersion = UseStaleVersion Bool
 -- 1. its name
 -- 2. how to track its version
 -- 3. how to fetch it as we have the version
--- 4. optional file paths to extract (dump to shake dir)
+-- 4. optional file paths to extract (dump to build dir)
 -- 5. optional @Cargo.lock@ path (if it's a rust package)
 -- 6. an optional pass through map
 -- 7. if the package version was pinned

--- a/src/NvFetcher/Utils.hs
+++ b/src/NvFetcher/Utils.hs
@@ -5,7 +5,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import Data.Text (Text)
 import qualified Data.Text as T
-import Development.Shake
+import System.Directory.Extra (XdgDirectory (XdgData), getXdgDirectory)
 import Text.Regex.TDFA ((=~))
 
 encode' :: Binary a => a -> BS.ByteString
@@ -17,9 +17,6 @@ decode' = decode . LBS.fromChunks . pure
 quote :: Text -> Text
 quote = T.pack . show
 
-getShakeDir :: Action FilePath
-getShakeDir = shakeFiles <$> getShakeOptions
-
 isLegalNixId :: Text -> Bool
 isLegalNixId x = x =~ "^[a-zA-Z_][a-zA-Z0-9_'-]*$"
 
@@ -27,3 +24,6 @@ quoteIfNeeds :: Text -> Text
 quoteIfNeeds x
   | isLegalNixId x = x
   | otherwise = quote x
+
+getDataDir :: IO FilePath
+getDataDir = getXdgDirectory XdgData "nvfetcher"

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -50,9 +50,13 @@ versionSourcesSpec = aroundShake $
       runNvcheckerRule (GitHubTag "harry-sanabria" "ReleaseTestRepo" $ def & ignored ?~ "second_release release3")
         `shouldReturnJust` Version "first_release"
 
-    specifyChan "http header" $ do
+    specifyChan "http header" $
       runNvcheckerRule (HttpHeader "https://www.unifiedremote.com/download/linux-x64-deb" "urserver-([\\d.]+).deb" def)
         >>= shouldBeJust
+
+    specifyChan "webpage" $
+      runNvcheckerRule (Webpage "http://ftp.vim.org/pub/vim/patches/7.3/" "7\\.3\\.\\d+" def)
+        `shouldReturnJust` Version "7.3.1314"
 
     specifyChan "manual" $
       runNvcheckerRule (Manual "Meow") `shouldReturnJust` Version "Meow"

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -54,9 +54,9 @@ versionSourcesSpec = aroundShake $
       runNvcheckerRule (HttpHeader "https://www.unifiedremote.com/download/linux-x64-deb" "urserver-([\\d.]+).deb" def)
         >>= shouldBeJust
 
-    specifyChan "webpage" $
-      runNvcheckerRule (Webpage "http://ftp.vim.org/pub/vim/patches/7.3/" "7\\.3\\.\\d+" def)
-        `shouldReturnJust` Version "7.3.1314"
+    -- specifyChan "webpage" $
+    --   runNvcheckerRule (Webpage "http://ftp.vim.org/pub/vim/patches/7.3/" "7\\.3\\.\\d+" def)
+    --     `shouldReturnJust` Version "7.3.1314"
 
     specifyChan "manual" $
       runNvcheckerRule (Manual "Meow") `shouldReturnJust` Version "Meow"

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -19,9 +19,9 @@ import Utils
 spec :: Spec
 spec = do
   versionSourcesSpec
-  useStaleSpec
+  -- TODO
+  before_ (pendingWith "We are relying on generated.json so the old test approach won't work") useStaleSpec
 
--- | We need a fakePackageKey here; otherwise the nvchecker rule would be cutoff
 versionSourcesSpec :: Spec
 versionSourcesSpec = aroundShake $
   describe "nvchecker" $ do

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -19,8 +19,7 @@ import Utils
 spec :: Spec
 spec = do
   versionSourcesSpec
-  -- TODO
-  before_ (pendingWith "We are relying on generated.json so the old test approach won't work") useStaleSpec
+  useStaleSpec
 
 versionSourcesSpec :: Spec
 versionSourcesSpec = aroundShake $

--- a/test/Utils.hs
+++ b/test/Utils.hs
@@ -37,7 +37,7 @@ type ActionQueue = TQueue (Action ())
 
 newAsyncActionQueue :: Map PackageKey Package -> IO (ActionQueue, Async ())
 newAsyncActionQueue pkgs = Extra.withTempDir $ \dir -> do
-  shakeExtras <- liftIO $ initShakeExtras pkgs 3
+  shakeExtras <- liftIO $ initShakeExtras pkgs 3 dir mempty
   chan <- atomically newTQueue
   (getShakeDb, _) <-
     shakeOpenDatabase


### PR DESCRIPTION
* There will be no shake database per project. Instead, a global one will be saved in `~/.local/share/nvfetcher/`. No need to commit and share the database!
* Based on `generated.json` (#54), Nvchecker rule will no longer depend on shake database. Instead, it uses versions in the json file. Closes #45
*  In order to get correct version changes and make stale version work, `generated.json` should be kept with `generated.nix` and should never be modified manually.

TODO:
* [x] Update README
* [x] Rework use stale test suite