### PR TITLE
Validate config before decoding

### DIFF
--- a/app/Config/PackageFetcher.hs
+++ b/app/Config/PackageFetcher.hs
@@ -5,7 +5,11 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
 
-module Config.PackageFetcher (fetcherCodec) where
+module Config.PackageFetcher
+  ( fetcherCodec,
+    fetcherKeys,
+  )
+where
 
 import Data.Coerce (coerce)
 import Data.Default (Default, def)
@@ -34,6 +38,17 @@ fetcherCodec =
       urlCodec,
       tarballCodec
     ]
+
+fetcherKeys :: [Key]
+fetcherKeys =
+  [ "fetch.github",
+    "fetch.pypi",
+    "fetch.openvsx",
+    "fetch.vsmarketplace",
+    "fetch.git",
+    "fetch.url",
+    "fetch.tarball"
+  ]
 
 --------------------------------------------------------------------------------
 

--- a/app/Config/VersionSource.hs
+++ b/app/Config/VersionSource.hs
@@ -2,7 +2,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
-module Config.VersionSource (versionSourceCodec) where
+module Config.VersionSource
+  ( versionSourceCodec,
+    versionSourceKeys,
+  )
+where
 
 import Data.Foldable (asum)
 import Data.Text (Text)
@@ -31,6 +35,22 @@ versionSourceCodec =
       vscodeMarketplaceCodec,
       cmdCodec
     ]
+
+versionSourceKeys :: [Key]
+versionSourceKeys =
+  [ "src.github",
+    "src.github_tag",
+    "src.git",
+    "src.pypi",
+    "src.archpkg",
+    "src.aur",
+    "src.manual",
+    "src.webpage",
+    "src.httpheader",
+    "src.openvsx",
+    "src.vsmarketplace",
+    "src.cmd"
+  ]
 
 --------------------------------------------------------------------------------
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -31,5 +31,5 @@ main = do
   case toml of
     Left e -> error $ T.unpack $ Toml.prettyTomlDecodeError $ Toml.ParseError e
     Right x -> case parseConfig x of
-      Left e -> error $ T.unpack $ Toml.prettyTomlDecodeErrors e
+      Left e -> error $ T.unpack $ prettyPackageConfigParseError e
       Right pkgs -> runNvFetcherNoCLI (applyCliOptions defaultArgs opt) $ purePackageSet pkgs


### PR DESCRIPTION
Configuration which has duplicate definitions like
```toml
[feeluown]
src.pypi = "feeluown"
fetch.pypi = "feeluown"
fetch.github = "feeluown/feeluown"
```
won't be acceptable.

Closes #36