### PR TITLE
Cache nvchecker result in each run

### DIFF
--- a/src/NvFetcher/Config.hs
+++ b/src/NvFetcher/Config.hs
@@ -11,7 +11,8 @@ data Config = Config
     actionAfterBuild :: Action (),
     actionAfterClean :: Action (),
     retry :: Int,
-    filterRegex :: Maybe String
+    filterRegex :: Maybe String,
+    cacheNvchecker :: Bool
   }
 
 instance Default Config where
@@ -27,5 +28,6 @@ instance Default Config where
         actionAfterBuild = pure (),
         actionAfterClean = pure (),
         retry = 3,
-        filterRegex = Nothing
+        filterRegex = Nothing,
+        cacheNvchecker = True
       }

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -49,7 +49,7 @@ coreRules = do
             _ppinned = (UseStaleVersion pinned),
             ..
           } -> do
-          _prversion@(NvcheckerResult version mOldV _isStale) <- checkVersion versionSource options pkg
+          _prversion@(NvcheckerResult version _mOldV _isStale) <- checkVersion versionSource options pkg
           _prfetched <- prefetch $ _pfetcher version
           buildDir <- getBuildDir
           -- extract src
@@ -91,6 +91,8 @@ coreRules = do
               _ -> pure (Nothing, Nothing)
 
           -- update changelog
+          -- always use on disk verion
+          mOldV <- getLastVersionOnDisk pkg
           case mOldV of
             Nothing ->
               recordVersionChange _pname Nothing version

--- a/src/NvFetcher/Nvchecker.hs
+++ b/src/NvFetcher/Nvchecker.hs
@@ -66,7 +66,7 @@ persistedRule = addBuiltinRule noLint noIdentity $ \(WithPackageKey (CheckVersio
       | Just oldVer' <- oldVer -> do
         -- use the stale version if we have
         putInfo $ T.unpack $ "Skip running nvchecker, use stale version " <> coerce oldVer' <> " for " <> coerce pkg
-        let result = NvcheckerResult {nvNow = oldVer', nvOld = Nothing, nvStale = True}
+        let result = NvcheckerResult {nvNow = oldVer', nvOld = oldVer, nvStale = True}
         pure $ RunResult ChangedRecomputeSame (encode' result) result
 
     -- run nvchecker

--- a/src/NvFetcher/Types.hs
+++ b/src/NvFetcher/Types.hs
@@ -174,9 +174,9 @@ data CheckVersion = CheckVersion VersionSource NvcheckerOptions
 -- | The result of nvchecker rule
 data NvcheckerResult = NvcheckerResult
   { nvNow :: Version,
-    -- | shake restores it from last run
+    -- | last result of this nvchecker rule
     nvOld :: Maybe Version,
-    -- | stale means even 'nvNow' comes from json file or last run
+    -- | stale means even 'nvNow' comes from json file (last run)
     -- and we actually didn't run nvchecker this time. 'nvOld' will be 'Nothing' in this case.
     nvStale :: Bool
   }

--- a/src/NvFetcher/Types.hs
+++ b/src/NvFetcher/Types.hs
@@ -175,6 +175,7 @@ data CheckVersion = CheckVersion VersionSource NvcheckerOptions
 data NvcheckerResult = NvcheckerResult
   { nvNow :: Version,
     -- | last result of this nvchecker rule
+    -- TODO: consider removing this field
     nvOld :: Maybe Version,
     -- | stale means even 'nvNow' comes from json file (last run)
     -- and we actually didn't run nvchecker this time. 'nvOld' will be 'Nothing' in this case.

--- a/src/NvFetcher/Types/ShakeExtras.hs
+++ b/src/NvFetcher/Types/ShakeExtras.hs
@@ -35,6 +35,10 @@ module NvFetcher.Types.ShakeExtras
     getRecentLastVersion,
     updateLastVersion,
     getAllOnDiskVersions,
+    getLastVersionUpdated,
+
+    -- * Cache nvchecker
+    nvcheckerCacheEnabled,
   )
 where
 
@@ -131,6 +135,15 @@ getRecentLastVersion k = do
     Just (OnDisk v) -> Just v
     _ -> Nothing
 
+-- | Get updated version of a package
+getLastVersionUpdated :: PackageKey -> Action (Maybe Version)
+getLastVersionUpdated k = do
+  ShakeExtras {..} <- getShakeExtras
+  versions <- liftIO $ readVar lastVersions
+  pure $ case versions Map.!? k of
+    Just (Updated _ v) -> Just v
+    _ -> Nothing
+
 -- | Add nvchecker result of a package
 updateLastVersion :: PackageKey -> Version -> Action ()
 updateLastVersion k v = do
@@ -151,3 +164,7 @@ getAllOnDiskVersions = do
           OnDisk v -> Just v
           Updated v _ -> v
   pure $ Map.fromList [(k, v) | (k, Just v) <- xs]
+
+-- | Get if 'cacheNvchecker' is enabled
+nvcheckerCacheEnabled :: Action Bool
+nvcheckerCacheEnabled = cacheNvchecker . config <$> getShakeExtras

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -91,7 +91,7 @@ useStaleSpec = aroundShake' (Map.singleton fakePackageKey fakePinnedPackage) def
 
     specifyChan "stale" $ do
       liftIO $ writeFile temp "Bark"
-      runNvcheckerRuleOnFakePackage versionSource `shouldReturnJust` NvcheckerResult {nvNow = "Meow", nvOld = Nothing, nvStale = True}
+      runNvcheckerRuleOnFakePackage versionSource `shouldReturnJust` NvcheckerResult {nvNow = "Meow", nvOld = Just "Meow", nvStale = True}
 
     runIO cleanup
 

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -9,6 +9,7 @@ import Data.Default (def)
 import qualified Data.Map.Strict as Map
 import qualified Data.Text as T
 import Lens.Micro
+import NvFetcher.Config (Config (cacheNvchecker))
 import NvFetcher.Nvchecker
 import NvFetcher.Types
 import NvFetcher.Types.Lens
@@ -20,6 +21,7 @@ spec :: Spec
 spec = do
   versionSourcesSpec
   useStaleSpec
+  cacheSpec
 
 versionSourcesSpec :: Spec
 versionSourcesSpec = aroundShake $
@@ -75,9 +77,9 @@ versionSourcesSpec = aroundShake $
 
 --------------------------------------------------------------------------------
 
--- | We need a new shake session for checking useStale working
+-- | We need disable nvchecker cache to see if use stale works
 useStaleSpec :: Spec
-useStaleSpec = aroundShake' (Map.singleton fakePackageKey pinnedPackage) $
+useStaleSpec = aroundShake' (Map.singleton fakePackageKey fakePinnedPackage) def {cacheNvchecker = False} $
   describe "useStale" $ do
     (temp, cleanup) <- runIO newTempFile
 
@@ -93,6 +95,23 @@ useStaleSpec = aroundShake' (Map.singleton fakePackageKey pinnedPackage) $
 
     runIO cleanup
 
+cacheSpec :: Spec
+cacheSpec = aroundShake' (Map.singleton fakePackageKey fakePackage) def {cacheNvchecker = True} $
+  describe "cache" $ do
+    (temp, cleanup) <- runIO newTempFile
+
+    let versionSource = Cmd $ "cat " <> T.pack temp
+
+    specifyChan "needs run" $ do
+      liftIO $ writeFile temp "Meow"
+      runNvcheckerRuleOnFakePackage versionSource `shouldReturnJust` NvcheckerResult {nvNow = "Meow", nvOld = Nothing, nvStale = False}
+
+    specifyChan "cache" $ do
+      liftIO $ writeFile temp "Bark"
+      runNvcheckerRuleOnFakePackage versionSource `shouldReturnJust` NvcheckerResult {nvNow = "Meow", nvOld = Just "Meow", nvStale = False}
+
+    runIO cleanup
+
 --------------------------------------------------------------------------------
 
 runNvcheckerRule :: VersionSource -> ReaderT ActionQueue IO (Maybe Version)
@@ -104,8 +123,8 @@ runNvcheckerRuleOnFakePackage v = runActionChan $ checkVersion v def fakePackage
 fakePackageKey :: PackageKey
 fakePackageKey = PackageKey "a-fake-package"
 
-pinnedPackage :: Package
-pinnedPackage =
+fakePackage :: Package
+fakePackage =
   Package
     { _pname = coerce fakePackageKey,
       _pversion = undefined,
@@ -113,5 +132,8 @@ pinnedPackage =
       _pcargo = undefined,
       _pextract = undefined,
       _ppassthru = undefined,
-      _ppinned = UseStaleVersion True
+      _ppinned = UseStaleVersion False
     }
+
+fakePinnedPackage :: Package
+fakePinnedPackage = fakePackage {_ppinned = UseStaleVersion True}


### PR DESCRIPTION
`nvchecker` should be executed at most one time in each run, in case `nvchecker` returns different results, i.e., the version changes in this single run, leading to inconsistencies.