### PR TITLE
Set pinned to true in package result json iff it was pinned in config

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -111,4 +112,12 @@ passthruCodec :: TomlCodec PackagePassthru
 passthruCodec = diwrap $ tableHashMap _KeyText text "passthru"
 
 pinnedCodec :: TomlCodec UseStaleVersion
-pinnedCodec = dimap (Just . coerce) (maybe (UseStaleVersion False) coerce) $ dioptional $ bool "pinned"
+pinnedCodec =
+  dimap
+    ( \case
+        PermanentStale -> Just True
+        TemporaryStale -> error "Impossible!"
+        NoStale -> Just False
+    )
+    (maybe NoStale (\x -> if x then PermanentStale else NoStale))
+    $ dioptional $ bool "pinned"

--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -74,7 +74,7 @@ import NvFetcher.Options
 import NvFetcher.PackageSet
 import NvFetcher.Types
 import NvFetcher.Types.ShakeExtras
-import NvFetcher.Utils (getDataDir, aesonKey)
+import NvFetcher.Utils (aesonKey, getDataDir)
 import qualified System.Directory.Extra as D
 import Text.Regex.TDFA ((=~))
 
@@ -161,10 +161,12 @@ runNvFetcherNoCLI config@Config {..} target packageSet = do
     pinIfUnmatch x@Package {..}
       | Just regex <- filterRegex =
         x
-          { _ppinned =
-              if coerce _ppinned || not (_pname =~ regex)
-                then UseStaleVersion True
-                else UseStaleVersion False
+          { _ppinned = case _ppinned of
+              PermanentStale -> PermanentStale
+              _ ->
+                if _pname =~ regex
+                  then NoStale
+                  else TemporaryStale
           }
       | otherwise = x
 

--- a/src/NvFetcher/Core.hs
+++ b/src/NvFetcher/Core.hs
@@ -46,7 +46,6 @@ coreRules = do
         Package
           { _pversion = CheckVersion versionSource options,
             _ppassthru = (PackagePassthru passthru),
-            _ppinned = (UseStaleVersion pinned),
             ..
           } -> do
           _prversion@(NvcheckerResult version _mOldV _isStale) <- checkVersion versionSource options pkg
@@ -106,7 +105,7 @@ coreRules = do
 
           let _prpassthru = if HMap.null passthru then Nothing else Just passthru
               _prname = _pname
-              _prpinned = pinned
+              _prpinned = _ppinned
           -- Since we don't save the previous result, we are not able to know if the result changes
           -- Depending on this rule leads to RunDependenciesChanged
           pure $ RunResult ChangedRecomputeDiff mempty PackageResult {..}

--- a/src/NvFetcher/Nvchecker.hs
+++ b/src/NvFetcher/Nvchecker.hs
@@ -60,9 +60,13 @@ nvcheckerRule = do
 persistedRule :: Rules ()
 persistedRule = addBuiltinRule noLint noIdentity $ \(WithPackageKey (CheckVersion versionSource options, pkg)) _old _mode -> do
   oldVer <- getRecentLastVersion pkg
-  useStale <- _ppinned . fromJust <$> lookupPackage pkg
+  useStaleVersion <- _ppinned . fromJust <$> lookupPackage pkg
+  let useStale = case useStaleVersion of
+        PermanentStale -> True
+        TemporaryStale -> True
+        _ -> False
   case useStale of
-    (UseStaleVersion True)
+    True
       | Just oldVer' <- oldVer -> do
         -- use the stale version if we have
         putInfo $ T.unpack $ "Skip running nvchecker, use stale version " <> coerce oldVer' <> " for " <> coerce pkg

--- a/src/NvFetcher/PackageSet.hs
+++ b/src/NvFetcher/PackageSet.hs
@@ -280,7 +280,7 @@ instance PkgDSL PackageSet where
       (projMaybe p)
       (projMaybe p)
       (fromMaybe mempty (projMaybe p))
-      (fromMaybe (UseStaleVersion False) (projMaybe p))
+      (fromMaybe NoStale (projMaybe p))
 
 -- | 'PkgDSL' version of 'newPackage'
 --
@@ -542,4 +542,4 @@ passthru = (. pure . PackagePassthru . HMap.fromList) . andThen
 --
 -- new version won't be checked if we have a stale version
 pinned :: PackageSet (Prod r) -> PackageSet (Prod (UseStaleVersion : r))
-pinned = flip andThen . pure $ UseStaleVersion True
+pinned = flip andThen . pure $ PermanentStale

--- a/test/CheckVersionSpec.hs
+++ b/test/CheckVersionSpec.hs
@@ -132,8 +132,8 @@ fakePackage =
       _pcargo = undefined,
       _pextract = undefined,
       _ppassthru = undefined,
-      _ppinned = UseStaleVersion False
+      _ppinned = NoStale
     }
 
 fakePinnedPackage :: Package
-fakePinnedPackage = fakePackage {_ppinned = UseStaleVersion True}
+fakePinnedPackage = fakePackage {_ppinned = PermanentStale}


### PR DESCRIPTION
Packages that don't match `--filter` will no longer lead to `pinned: true` in `generated.json`.

Closes #62