### PR TITLE
Clean build dir before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ Basically, there are two ways to use nvfetcher, where the difference is how we p
 To run nvfetcher as a CLI program, you'll need to provide package sources defined in TOML.
 
 ```
-Usage: nvfetcher [--version] [--help] [-o|--build-dir DIR] [--commit-changes]
-                 [-l|--changelog FILE] [-j NUM] [-r|--retry NUM] [-t|--timing]
-                 [-v|--verbose] [-f|--filter REGEX] [-k|--keyfile FILE] [TARGET]
-                 [-c|--config FILE]
+Usage: nvfetcher [--version] [--help] [-o|--build-dir DIR] [--commit-changes] 
+                 [-l|--changelog FILE] [-j NUM] [-r|--retry NUM] [-t|--timing] 
+                 [-v|--verbose] [-f|--filter REGEX] [-k|--keyfile FILE] 
+                 [--keep-old] [TARGET] [-c|--config FILE]
+
   generate nix sources expr for the latest version of packages
 
 Available options:
@@ -125,7 +126,10 @@ Available options:
   -v,--verbose             Verbose mode
   -f,--filter REGEX        Regex to filter packages to be updated
   -k,--keyfile FILE        Nvchecker keyfile
-  TARGET                   Two targets are available: 1.build 2.clean
+  --keep-old               Don't remove old files other than generated json and
+                           nix before build
+  TARGET                   Three targets are available: 1.build 2.clean (remove
+                           all generated files) 3.purge (remove shake db)
                            (default: build)
   -c,--config FILE         Path to nvfetcher TOML config
                            (default: "nvfetcher.toml")

--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -51,7 +51,7 @@ module NvFetcher
   )
 where
 
-import Control.Monad.Extra (forM_, when, whenJust)
+import Control.Monad.Extra (forM_, unless, when, whenJust, whenM)
 import qualified Data.Aeson as A
 import qualified Data.Aeson.Encode.Pretty as A
 import qualified Data.Aeson.Types as A
@@ -113,7 +113,8 @@ applyCliOptions config CLIOptions {..} = do
             },
         filterRegex = optPkgNameFilter,
         retry = optRetry,
-        keyfile = aKeyfile
+        keyfile = aKeyfile,
+        keepOldFiles = optKeepOldFiles
       }
 
 logChangesToFile :: FilePath -> Action ()
@@ -167,14 +168,14 @@ runNvFetcherNoCLI config@Config {..} target packageSet = do
     -- Don't touch already pinned packages
     pinIfUnmatch x@Package {..}
       | Just regex <- filterRegex =
-        x
-          { _ppinned = case _ppinned of
-              PermanentStale -> PermanentStale
-              _ ->
-                if _pname =~ regex
-                  then NoStale
-                  else TemporaryStale
-          }
+          x
+            { _ppinned = case _ppinned of
+                PermanentStale -> PermanentStale
+                _ ->
+                  if _pname =~ regex
+                    then NoStale
+                    else TemporaryStale
+            }
       | otherwise = x
 
 --------------------------------------------------------------------------------
@@ -185,7 +186,19 @@ mainRules Config {..} = do
     getBuildDir >>= flip removeFilesAfter ["//*"]
     actionAfterClean
 
+  "purge" ~> do
+    shakeDir <- shakeFiles <$> getShakeOptions
+    removeFilesAfter shakeDir ["//*"]
+
   "build" ~> do
+    -- remove all files in build dir except generated nix and json
+    -- since core rule has always rerun, any file not generated in this run will be removed
+    unless keepOldFiles $
+      whenM (liftIO $ D.doesDirectoryExist buildDir) $ do
+        oldFiles <- (\\ [generatedJsonFileName, generatedNixFileName]) <$> liftIO (D.listDirectory buildDir)
+        putVerbose $ "Removing old files: " <> show oldFiles
+        liftIO $ removeFiles buildDir oldFiles
+    -- removeFiles buildDir $ oldFiles \\ [generatedNixFileName, generatedJsonFileName]
     allKeys <- getAllPackageKeys
     results <- parallel $ runPackage <$> allKeys
     -- Record removed packages to version changes

--- a/src/NvFetcher/Config.hs
+++ b/src/NvFetcher/Config.hs
@@ -18,6 +18,7 @@ data Config = Config
     retry :: Int,
     filterRegex :: Maybe String,
     cacheNvchecker :: Bool,
+    keepOldFiles :: Bool,
     -- | Absolute path
     keyfile :: Maybe FilePath
   }
@@ -37,5 +38,6 @@ instance Default Config where
         retry = 3,
         filterRegex = Nothing,
         cacheNvchecker = True,
+        keepOldFiles = False,
         keyfile = Nothing
       }

--- a/src/NvFetcher/Options.hs
+++ b/src/NvFetcher/Options.hs
@@ -19,17 +19,19 @@ where
 import Options.Applicative.Simple
 import qualified Paths_nvfetcher as Paths
 
-data Target = Build | Clean
+data Target = Build | Clean | Purge
   deriving (Eq)
 
 instance Show Target where
   show Build = "build"
   show Clean = "clean"
+  show Purge = "purge"
 
 targetParser :: ReadM Target
 targetParser = maybeReader $ \case
   "build" -> Just Build
   "clean" -> Just Clean
+  "purge" -> Just Purge
   _ -> Nothing
 
 -- | Options for nvfetcher CLI
@@ -43,6 +45,7 @@ data CLIOptions = CLIOptions
     optVerbose :: Bool,
     optPkgNameFilter :: Maybe String,
     optKeyfile :: Maybe FilePath,
+    optKeepOldFiles :: Bool,
     optTarget :: Target
   }
   deriving (Show)
@@ -108,12 +111,13 @@ cliOptionsParser =
               <> completer (bashCompleter "file")
           )
       )
+    <*> switch (long "keep-old" <> help "Don't remove old files other than generated json and nix before build")
     <*> argument
       targetParser
       ( metavar "TARGET"
-          <> help "Two targets are available: 1.build  2.clean"
+          <> help "Three targets are available: 1.build  2.clean (remove all generated files) 3.purge (remove shake db)"
           <> value Build
-          <> completer (listCompleter [show Build, show Clean])
+          <> completer (listCompleter [show Build, show Clean, show Purge])
           <> showDefault
       )
 


### PR DESCRIPTION
Closes #111

* Any files except `generated.json` and `generated.nix` in `_sources` will be removed before each run.
* A new CLI option `--keep-old` is added to prevent this operation.
* A new target `purge` is added, which resets the state of nvfetcher by deleting shake database 
