### PR TITLE
Bump shake version

### DIFF
--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -157,8 +157,8 @@ runNvFetcherNoCLI config@Config {..} target packageSet = do
   pkgs <- Map.map pinIfUnmatch <$> runPackageSet packageSet
   lastVersions <- parseLastVersions $ buildDir </> generatedJsonFileName
   shakeDir <- getDataDir
-  -- Set shakeFiles
-  let shakeOptions1 = shakeConfig {shakeFiles = shakeDir}
+  -- Set shakeFiles and shakeVersion
+  let shakeOptions1 = shakeConfig {shakeFiles = shakeDir, shakeVersion = "2"}
   -- shakeConfig in Config will be shakeOptions1 (not including shake extra)
   shakeExtras <- initShakeExtras (config {shakeConfig = shakeOptions1}) pkgs $ fromMaybe mempty lastVersions
   -- Set shakeExtra

--- a/src/NvFetcher/Config.hs
+++ b/src/NvFetcher/Config.hs
@@ -31,8 +31,7 @@ instance Default Config where
       { shakeConfig =
           shakeOptions
             { shakeProgress = progressSimple,
-              shakeThreads = 0,
-              shakeVersion = "1"
+              shakeThreads = 0
             },
         buildDir = "_sources",
         customRules = pure (),


### PR DESCRIPTION
Closes #117

The Core rule was changed in #115, and thus shake version needs to be bumped. However, I actually failed to this in #115:

https://github.com/berberman/nvfetcher/blob/367e2eaa92d8f5133c2c5ac03a80c0cf25f301b8/src/NvFetcher/Config.hs#L35

Since the default value is `"1"`.