### PR TITLE
add --commit-summary

### DIFF
--- a/src/NvFetcher.hs
+++ b/src/NvFetcher.hs
@@ -103,7 +103,7 @@ applyCliOptions config CLIOptions {..} = do
       { buildDir = optBuildDir,
         actionAfterBuild = do
           whenJust optLogPath logChangesToFile
-          when optCommit commitChanges
+          when optCommit (commitChanges (fromMaybe "Update" optCommitSummary))
           actionAfterBuild config,
         shakeConfig =
           (shakeConfig config)
@@ -123,12 +123,12 @@ logChangesToFile fp = do
   changes <- getVersionChanges
   writeFile' fp $ unlines $ show <$> changes
 
-commitChanges :: Action ()
-commitChanges = do
+commitChanges :: String -> Action ()
+commitChanges commitSummary = do
   changes <- getVersionChanges
   let commitMsg = case changes of
         [x] -> Just $ show x
-        xs@(_ : _) -> Just $ "Update\n" <> unlines (show <$> xs)
+        xs@(_ : _) -> Just $ commitSummary <> "\n" <> unlines (show <$> xs)
         [] -> Nothing
   whenJust commitMsg $ \msg -> do
     putInfo "Commiting changes"

--- a/src/NvFetcher/Options.hs
+++ b/src/NvFetcher/Options.hs
@@ -38,6 +38,7 @@ targetParser = maybeReader $ \case
 data CLIOptions = CLIOptions
   { optBuildDir :: FilePath,
     optCommit :: Bool,
+    optCommitSummary :: Maybe String,
     optLogPath :: Maybe FilePath,
     optThreads :: Int,
     optRetry :: Int,
@@ -66,6 +67,13 @@ cliOptionsParser =
     <*> switch
       ( long "commit-changes"
           <> help "`git commit` build dir with version changes as commit message"
+      )
+    <*> optional
+      ( strOption
+          ( long "commit-summary"
+              <> metavar "SUMMARY"
+              <> help "Summary to use when committing changes"
+          )
       )
     <*> optional
       ( strOption


### PR DESCRIPTION
this is an extension of the current `--commit-changes` flag that allows for setting the summary of the created commit -- similar to the unstable `nix` cli. this will help users who want to keep the helpful update information, but still have the commit conform to specific conventions