### PR TITLE
Allow $ver placeholder in URL names

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ How do we fetch the package source if we have the target version number?
 - `fetch.docker = owner/name`
 
 Optional config for `nix-prefetch-url`, applies when the fetcher equals to `fetch.url`.
+`$ver` is available in string, just like for the fetch config.
 
 - `url.name = file_name`
 

--- a/app/Config/PackageFetcher.hs
+++ b/app/Config/PackageFetcher.hs
@@ -121,7 +121,7 @@ urlDecoder :: Decoder PackageFetcher
 urlDecoder = do
   url <- getFields ["fetch", "url"]
   name <- getFieldsOpt ["url", "name"]
-  pure $ \(coerce -> v) -> urlFetcher' (T.replace "$ver" v url) name
+  pure $ \(coerce -> v) -> urlFetcher' (T.replace "$ver" v url) (fmap (T.replace "$ver" v) name)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Just like the $ver placeholder is supported for the URL itself.